### PR TITLE
Change API for `annotate*` methods to take closures.

### DIFF
--- a/src/annres.rs
+++ b/src/annres.rs
@@ -1,11 +1,16 @@
 use crate::{annotate, ErrorAnnotation};
 
 pub trait AnnotateResult<T, E> {
-    fn annotate_err<I>(self, label: &'static str, info: I) -> Result<T, ErrorAnnotation<E, I>>;
+    fn annotate_err<F, I>(self, label: &'static str, mkinfo: F) -> Result<T, ErrorAnnotation<E, I>>
+    where
+        F: FnOnce() -> I;
 }
 
 impl<T, E> AnnotateResult<T, E> for Result<T, E> {
-    fn annotate_err<I>(self, label: &'static str, info: I) -> Result<T, ErrorAnnotation<E, I>> {
-        self.map_err(annotate(label, info))
+    fn annotate_err<F, I>(self, label: &'static str, mkinfo: F) -> Result<T, ErrorAnnotation<E, I>>
+    where
+        F: FnOnce() -> I,
+    {
+        self.map_err(annotate(label, mkinfo))
     }
 }

--- a/src/ea.rs
+++ b/src/ea.rs
@@ -1,7 +1,10 @@
 use std::fmt;
 
-pub fn annotate<S, I>(label: &'static str, info: I) -> impl FnOnce(S) -> ErrorAnnotation<S, I> {
-    ErrorAnnotation::annotate(label, info)
+pub fn annotate<S, F, I>(label: &'static str, mkinfo: F) -> impl FnOnce(S) -> ErrorAnnotation<S, I>
+where
+    F: FnOnce() -> I,
+{
+    ErrorAnnotation::annotate(label, mkinfo)
 }
 
 pub struct ErrorAnnotation<S, I> {
@@ -21,11 +24,14 @@ where
 }
 
 impl<S, I> ErrorAnnotation<S, I> {
-    pub fn annotate(label: &'static str, info: I) -> impl FnOnce(S) -> Self {
+    pub fn annotate<F>(label: &'static str, mkinfo: F) -> impl FnOnce(S) -> Self
+    where
+        F: FnOnce() -> I,
+    {
         move |source| ErrorAnnotation {
             source,
             label,
-            info,
+            info: mkinfo(),
         }
     }
 }


### PR DESCRIPTION
Taking closures allows postponing expensive operations until the error cases are propagating. It also allows transforming values, such as `Path::display`. (The test simplifications for `Path` tests demonstrates this benefit.)