### PR TITLE
Annotatable

### DIFF
--- a/src/annotatable.rs
+++ b/src/annotatable.rs
@@ -1,47 +1,14 @@
 use crate::ErrorAnnotation;
 use std::fmt::Display;
 
-/// An `Annotatable` error type is can convert an `ErrorAnnotation` with `Self` as the source type
-/// back into `Self`, provided the annotated `info` implements `Display`.
+/// An `Annotatable` error type is can convert an [ErrorAnnotation] with `Self` as the source type
+/// back into `Self`, provided the annotated `info` implements [std::fmt::Display].
 ///
-/// A prime example is the `std::io::Error` impl, which can be used to convert any annotation on a
-/// `std::io::Error` back into a `std::io::Error`.
-///
-/// Errors which implement `Annotatable` allow code to introduce annotations without all of the
-/// various diagnostic information resulting in a plethora of uniquely parameterized
-/// `ErrorAnnotation` types. This can be convenient, for example, to prevent `ErrorAnnotation`
-/// types from leaking out into a crate's interface, so that consumers need only handle common base
-/// error types, such as `std::io::Error`.
+/// A prime example is the [std::io::Error] impl, which can be used to convert any annotation on a
+/// [std::io::Error] back into a [std::io::Error], as the [`crate`]-level example demonstrates.
 ///
 /// The conversion provided by implementations of `Annotatable` is typically conveniently
-/// accomplished via `AnnotateResult::annotate_err_into`.
-///
-/// # Example
-///
-/// ```
-/// use std::path::{Path, PathBuf};
-/// use std::fs::Metadata;
-/// use error_annotation::{AnnotateResult, ErrorAnnotation};
-///
-/// fn annotated_copy(src: &Path, dst: &Path) -> std::io::Result<u64> {
-///   std::fs::copy(src, dst)
-///     .annotate_err_into("source", || src.display())
-///     .annotate_err_into("destination", || dst.display())
-/// }
-///
-/// let badsource = PathBuf::from("/this/path/does/not/exist");
-/// let dest = PathBuf::from("/tmp/woah-dude");
-/// let res = annotated_copy(&badsource, &dest);
-/// let err = res.err().unwrap();
-///
-/// assert_eq!(&err.to_string(), "
-///
-/// No such file or directory (os error 2)
-/// -with source: /this/path/does/not/exist
-/// -with destination: /tmp/woah-dude
-///
-/// ".trim());
-/// ```
+/// accomplished via [AnnotateResult::annotate_err_into](crate::AnnotateResult::annotate_err_into).
 pub trait Annotatable: Sized {
     fn merge_annotation<I>(ea: ErrorAnnotation<Self, I>) -> Self
     where

--- a/src/annotatable.rs
+++ b/src/annotatable.rs
@@ -1,0 +1,58 @@
+use crate::ErrorAnnotation;
+use std::fmt::Display;
+
+/// An `Annotatable` error type is can convert an `ErrorAnnotation` with `Self` as the source type
+/// back into `Self`, provided the annotated `info` implements `Display`.
+///
+/// A prime example is the `std::io::Error` impl, which can be used to convert any annotation on a
+/// `std::io::Error` back into a `std::io::Error`.
+///
+/// Errors which implement `Annotatable` allow code to introduce annotations without all of the
+/// various diagnostic information resulting in a plethora of uniquely parameterized
+/// `ErrorAnnotation` types. This can be convenient, for example, to prevent `ErrorAnnotation`
+/// types from leaking out into a crate's interface, so that consumers need only handle common base
+/// error types, such as `std::io::Error`.
+///
+/// The conversion provided by implementations of `Annotatable` is typically conveniently
+/// accomplished via `AnnotateResult::annotate_err_into`.
+///
+/// # Example
+///
+/// ```
+/// use std::path::{Path, PathBuf};
+/// use std::fs::Metadata;
+/// use error_annotation::{AnnotateResult, ErrorAnnotation};
+///
+/// fn annotated_copy(src: &Path, dst: &Path) -> std::io::Result<u64> {
+///   std::fs::copy(src, dst)
+///     .annotate_err_into("source", || src.display())
+///     .annotate_err_into("destination", || dst.display())
+/// }
+///
+/// let badsource = PathBuf::from("/this/path/does/not/exist");
+/// let dest = PathBuf::from("/tmp/woah-dude");
+/// let res = annotated_copy(&badsource, &dest);
+/// let err = res.err().unwrap();
+///
+/// assert_eq!(&err.to_string(), "
+///
+/// No such file or directory (os error 2)
+/// -with source: /this/path/does/not/exist
+/// -with destination: /tmp/woah-dude
+///
+/// ".trim());
+/// ```
+pub trait Annotatable: Sized {
+    fn merge_annotation<I>(ea: ErrorAnnotation<Self, I>) -> Self
+    where
+        I: Display;
+}
+
+impl Annotatable for std::io::Error {
+    fn merge_annotation<I>(ea: ErrorAnnotation<Self, I>) -> Self
+    where
+        I: Display,
+    {
+        Self::new(ea.source.kind(), ea.to_string())
+    }
+}

--- a/src/annotate.rs
+++ b/src/annotate.rs
@@ -1,6 +1,7 @@
 use crate::ErrorAnnotation;
 
-/// Capture diagnostic information in a closure that extends a source error type.
+/// Capture diagnostic information in a closure that extends a source error type into a wrapping
+/// [`ErrorAnnotation`].
 ///
 /// `annotate` captures a `label` and a diagnostic `info` construction closure, `mkinfo`, returning
 /// a closure that creates an [`ErrorAnnotation`] given a source error of type `S`. This API design

--- a/src/annres.rs
+++ b/src/annres.rs
@@ -1,4 +1,4 @@
-use crate::{annotate, ErrorAnnotation};
+use crate::{annotate, Annotatable, ErrorAnnotation};
 
 /// A trait to extend `Result` with a convenient `annotate_err` method. This is the recommended
 /// interface for annotating errors directly on `Result` values.
@@ -31,6 +31,17 @@ pub trait AnnotateResult<T, E> {
     fn annotate_err<F, I>(self, label: &'static str, mkinfo: F) -> Result<T, ErrorAnnotation<E, I>>
     where
         F: FnOnce() -> I;
+
+    fn annotate_err_into<F, I>(self, label: &'static str, mkinfo: F) -> Result<T, E>
+    where
+        Self: Sized,
+        E: Annotatable,
+        F: FnOnce() -> I,
+        I: std::fmt::Display,
+    {
+        self.annotate_err(label, mkinfo)
+            .map_err(E::merge_annotation)
+    }
 }
 
 impl<T, E> AnnotateResult<T, E> for Result<T, E> {

--- a/src/annres.rs
+++ b/src/annres.rs
@@ -2,36 +2,62 @@ use crate::{annotate, Annotatable, ErrorAnnotation};
 
 /// A trait to extend `Result` with a convenient `annotate_err` method. This is the recommended
 /// interface for annotating errors directly on `Result` values.
-///
-/// # Example
-///
-/// ```
-/// use std::path::{Path, PathBuf};
-/// use std::fs::Metadata;
-/// use error_annotation::{AnnotateResult, ErrorAnnotation};
-///
-/// type IoErrorWithPath<'a> = ErrorAnnotation<std::io::Error, std::path::Display<'a>>;
-///
-/// fn metadata(p: &Path) -> Result<Metadata, IoErrorWithPath> {
-///   std::fs::metadata(p).annotate_err("path", || p.display())
-/// }
-///
-/// let badpath = PathBuf::from("/this/path/does/not/exist");
-/// let res = metadata(&badpath);
-/// let err = res.err().unwrap();
-///
-/// assert_eq!(&err.to_string(), "
-///
-/// No such file or directory (os error 2)
-/// -with path: /this/path/does/not/exist
-///
-/// ".trim());
-/// ```
 pub trait AnnotateResult<T, E> {
+    /// Extends an `Err` source error with diagnostics into a [`ErrorAnnotation`].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use std::path::{Path, PathBuf};
+    /// use std::fs::Metadata;
+    /// use error_annotation::{AnnotateResult, ErrorAnnotation};
+    ///
+    /// type IoErrorWithPath<'a> = ErrorAnnotation<std::io::Error, std::path::Display<'a>>;
+    ///
+    /// fn metadata(p: &Path) -> Result<Metadata, IoErrorWithPath> {
+    ///   std::fs::metadata(p).annotate_err("path", || p.display())
+    /// }
+    ///
+    /// let badpath = PathBuf::from("/this/path/does/not/exist");
+    /// let res = metadata(&badpath);
+    /// let err = res.err().unwrap();
+    ///
+    /// assert_eq!(&err.to_string(), "
+    ///
+    /// No such file or directory (os error 2)
+    /// -with path: /this/path/does/not/exist
+    ///
+    /// ".trim());
+    /// ```
     fn annotate_err<F, I>(self, label: &'static str, mkinfo: F) -> Result<T, ErrorAnnotation<E, I>>
     where
         F: FnOnce() -> I;
 
+    /// Extends an `Err` source error with diagnostics into the same error type, provided it
+    /// implements [`Annotatable`].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use std::path::{Path, PathBuf};
+    /// use std::fs::Metadata;
+    /// use error_annotation::{AnnotateResult, ErrorAnnotation};
+    ///
+    /// fn metadata(p: &Path) -> std::io::Result<Metadata> {
+    ///   std::fs::metadata(p).annotate_err_into("path", || p.display())
+    /// }
+    ///
+    /// let badpath = PathBuf::from("/this/path/does/not/exist");
+    /// let res = metadata(&badpath);
+    /// let err: std::io::Error = res.err().unwrap();
+    ///
+    /// assert_eq!(&err.to_string(), "
+    ///
+    /// No such file or directory (os error 2)
+    /// -with path: /this/path/does/not/exist
+    ///
+    /// ".trim());
+    /// ```
     fn annotate_err_into<F, I>(self, label: &'static str, mkinfo: F) -> Result<T, E>
     where
         Self: Sized,

--- a/src/ea.rs
+++ b/src/ea.rs
@@ -4,76 +4,6 @@ use std::fmt;
 ///
 /// `ErrorAnnotation` combines a `source` error of type `S` with diagnostic `info` of type `I`
 /// which will be labeled with `label` when displayed.
-///
-/// # `std::io::Error` ergonomics
-///
-/// A `ErrorAnnotation<std::io::Error, I>` can be converted into a `std::io::Error` (via `From` /
-/// `Into` traits) provided that `I` implements `Display`. The `ErrorKind` is propagated while the
-/// string description includes the formatted annotations.
-///
-/// ## Example
-///
-/// ```
-/// use std::path::{Path, PathBuf};
-/// use std::fs::Metadata;
-/// use error_annotation::{AnnotateResult, ErrorAnnotation};
-///
-/// fn annotated_metadata(p: &Path) -> std::io::Result<Metadata> {
-///   let m = std::fs::metadata(p).annotate_err("path", || p.display())?;
-///   Ok(m)
-/// }
-///
-/// let badpath = PathBuf::from("/this/path/does/not/exist");
-/// let res = annotated_metadata(&badpath);
-/// let err = res.err().unwrap();
-///
-/// assert_eq!(&err.to_string(), "
-///
-/// No such file or directory (os error 2)
-/// -with path: /this/path/does/not/exist
-///
-/// ".trim());
-/// ```
-///
-/// # Multiple Annotations
-///
-/// Multiple annotations can be tracked by using an `ErrorAnnotation` type as a source, ie:
-/// `ErrorAnnotation<ErrorAnnotation<MyError, String>, usize>`.
-///
-/// Annotating errors with a nested type comes from simply chaining the annotation methods.
-///
-/// If the outermost `ErrorAnnotation` needs to be converted into a `std::io::Error`, the
-/// intermediate `ErrorAnnotation` values must be explicitly converted into `std::io::Error` when
-/// chaining in this way.
-///
-/// ## Example
-///
-/// ```
-/// use std::path::{Path, PathBuf};
-/// use std::fs::Metadata;
-/// use error_annotation::{AnnotateResult, ErrorAnnotation};
-///
-/// fn annotated_copy(src: &Path, dst: &Path) -> std::io::Result<u64> {
-///   let bytes = std::fs::copy(src, dst)
-///     .annotate_err("source", || src.display())
-///     .map_err(std::io::Error::from)
-///     .annotate_err("destination", || dst.display())?;
-///   Ok(bytes)
-/// }
-///
-/// let badsource = PathBuf::from("/this/path/does/not/exist");
-/// let dest = PathBuf::from("/tmp/woah-dude");
-/// let res = annotated_copy(&badsource, &dest);
-/// let err = res.err().unwrap();
-///
-/// assert_eq!(&err.to_string(), "
-///
-/// No such file or directory (os error 2)
-/// -with source: /this/path/does/not/exist
-/// -with destination: /tmp/woah-dude
-///
-/// ".trim());
-/// ```
 pub struct ErrorAnnotation<S, I> {
     pub source: S,
     pub label: &'static str,
@@ -87,14 +17,5 @@ where
 {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{}\n-with {}: {}", self.source, self.label, self.info)
-    }
-}
-
-impl<I> From<ErrorAnnotation<std::io::Error, I>> for std::io::Error
-where
-    I: fmt::Display,
-{
-    fn from(ea: ErrorAnnotation<std::io::Error, I>) -> std::io::Error {
-        std::io::Error::new(ea.source.kind(), ea.to_string())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,46 @@
 //! Add useful diagnostic information to error values as they propagate.
 //!
-//! The recommended way to annotate errors directly from a `Result` value is with the
-//! [`AnnotateResult::annotate_err`] method which is implemented on `Result`.
+//! # Annotatable Error Types
+//!
+//! The most ergonomic usage is available for types that implement [`Annotatable`] via the
+//! [`AnnotateResult::annotate_err_into`] method, which is implemented for `Result`. In this case,
+//! diagnostic annotations can be built up without altering the resulting error types. An example
+//! using the `std::io::Error` impl of `Annotatable` clarifies these ergonomics:
+//!
+//! ## Example: Chaining Diagnostic Annotations on `std::io::Error`
+//!
+//! ```
+//! use std::path::{Path, PathBuf};
+//! use std::fs::Metadata;
+//! use error_annotation::{AnnotateResult, ErrorAnnotation};
+//!
+//! fn annotated_copy(src: &Path, dst: &Path) -> std::io::Result<u64> {
+//!   std::fs::copy(src, dst)
+//!     .annotate_err_into("source", || src.display())
+//!     .annotate_err_into("destination", || dst.display())
+//! }
+//!
+//! let badsource = PathBuf::from("/this/path/does/not/exist");
+//! let dest = PathBuf::from("/tmp/woah-dude");
+//! let res = annotated_copy(&badsource, &dest);
+//! let err = res.err().unwrap();
+//!
+//! assert_eq!(&err.to_string(), "
+//!
+//! No such file or directory (os error 2)
+//! -with source: /this/path/does/not/exist
+//! -with destination: /tmp/woah-dude
+//!
+//! ".trim());
+//! ```
+//!
+//! # Annotating Other Error Types
+//!
+//! It is still possible to annotate an arbitrary error type `T` which does not implement [`Annotatable`]
+//! with annotation info type `I` by way of the [`ErrorAnnotation`]
+//! parameterized type. The downside being each annotation corresponds to a different
+//! parameterization, ie `ErrorAnnotation<T, I>`, which propagates out of interfaces and must be
+//! explicitly handled by consuming code.
 
 mod annotatable;
 mod annotate;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,10 +3,12 @@
 //! The recommended way to annotate errors directly from a `Result` value is with the
 //! [`AnnotateResult::annotate_err`] method which is implemented on `Result`.
 
+mod annotatable;
 mod annotate;
 mod annres;
 mod ea;
 
+pub use self::annotatable::Annotatable;
 pub use self::annotate::annotate;
 pub use self::annres::AnnotateResult;
 pub use self::ea::ErrorAnnotation;


### PR DESCRIPTION
Move away from the `From` approach to `Annotatable` which has good ergonomics, as the first crate-level doc example now shows.